### PR TITLE
Additional minor fixes to Cblas

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ ifdef TIMEOUT
 	TIMEOUT = timeout -k 5s $(OVO_TIMEOUT)
 endif
 
-MATH_LIB_FLAGS=-fsycl -qmkl
+MATH_LIB_FLAGS=-fiopenmp -fopenmp-targets=spir64  -fsycl  -L${MKLROOT}/lib/intel64 -lmkl_sycl -lmkl_intel_ilp64 -lmkl_intel_thread -lmkl_core -liomp5 -lsycl -lOpenCL -lstdc++ -lpthread -lm -ldl
 
 SRC = $(wildcard *.cpp)
 .PHONY: exe
@@ -14,7 +14,7 @@ pEXE = $(wildcard *.exe)
 .PHONY: run
 run: $(addprefix run_, $(basename $(pEXE)))
 
-CXXFLAGS = -fiopenmp -fopenmp-targets=spir64 -DMKL_ILP64
+CXXFLAGS = -fiopenmp -fopenmp-targets=spir64 -DMKL_ILP64 -I${MKLROOT}/include
 
 %.exe: %.cpp
 	-$(CXX) $(CXXFLAGS) $(MATH_LIB_FLAGS) $< -o $@

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,15 @@ ifdef TIMEOUT
 	TIMEOUT = timeout -k 5s $(OVO_TIMEOUT)
 endif
 
-MATH_LIB_FLAGS=-fiopenmp -fopenmp-targets=spir64  -fsycl  -L${MKLROOT}/lib/intel64 -lmkl_sycl -lmkl_intel_ilp64 -lmkl_intel_thread -lmkl_core -liomp5 -lsycl -lOpenCL -lstdc++ -lpthread -lm -ldl
+# From MKL linkline advisor
+# https://software.intel.com/content/www/us/en/develop/tools/oneapi/components/onemkl/link-line-advisor.html
+ifeq (${ILP64},1)
+	CXXFLAGS=-fiopenmp -fopenmp-targets=spir64 -DMKL_ILP64 -I${MKLROOT}/include
+	MATH_LIB_FLAGS=-fsycl  -L${MKLROOT}/lib/intel64 -lmkl_sycl -lmkl_intel_ilp64 -lmkl_intel_thread -lmkl_core -liomp5 -lsycl -lOpenCL -lstdc++ -lpthread -lm -ldl
+else
+	CXXFLAGS=-fiopenmp -fopenmp-targets=spir64 -I${MKLROOT}/include
+	MATH_LIB_FLAGS=-fsycl  -L${MKLROOT}/lib/intel64 -lmkl_sycl -lmkl_intel_lp64 -lmkl_intel_thread -lmkl_core -liomp5 -lsycl -lOpenCL -lstdc++ -lpthread -lm -ldl
+endif
 
 SRC = $(wildcard *.cpp)
 .PHONY: exe
@@ -13,8 +21,6 @@ exe: $(SRC:%.cpp=%.exe)
 pEXE = $(wildcard *.exe)
 .PHONY: run
 run: $(addprefix run_, $(basename $(pEXE)))
-
-CXXFLAGS = -fiopenmp -fopenmp-targets=spir64 -DMKL_ILP64 -I${MKLROOT}/include
 
 %.exe: %.cpp
 	-$(CXX) $(CXXFLAGS) $(MATH_LIB_FLAGS) $< -o $@

--- a/gtest.py
+++ b/gtest.py
@@ -30,6 +30,7 @@ for dirName, subdirList, fileList in os.walk(rootDir):
 # blas_match = 'cblas_.gemm'
 blas_match = 'cblas_.....'
 rot_match = 'cblas_.rot.'
+specialK_match = 'cblas_..b.v' # K for these functions need to be scaled down by at least a factor of 2
 
 for function in functions:
     function_name = function[0]
@@ -37,6 +38,8 @@ for function in functions:
     # This bit of code will be removed in the future, but for now its just for testing certain functions
     found_blas = re.search(r'\b' + blas_match + r'\b',function_name)
     found_rot = re.search(r'\b' + rot_match + r'\b',function_name)
+    found_specialK = re.search(r'\b' + specialK_match + r'\b',function_name)
+
     if found_blas:
         if found_rot: # don't generate these
             continue
@@ -64,6 +67,9 @@ for function in functions:
     l_types_names_ = []
     # look at argument types and intents
     for atype, intent, name, size  in zip(argument_types,argument_intents,argument_names,argument_sizes) :
+        if found_specialK:
+            if name == "K": # scaled down by at least a factor of 2
+                size = int(size/2)
         if intent != "return":
             if "*" in atype:
                 l_types_names_.append( [size,True, intent,atype[:len(atype)-1], name] )

--- a/parse_header.py
+++ b/parse_header.py
@@ -42,6 +42,9 @@ def varvalues(varname, vartype):
     Pointers types are gives sizes, but scalars are given initial values.
 
     Inputs is the variable name from the header file as obtain by fparse function.
+
+    Input parameters are not checked for compatbility with the MKL function that used them.
+    Some incompatibilities are noted and enforced with assert statements.
     '''
 
     FortranAPI = False # controls some operations, e.g. transpose, uplo,
@@ -54,9 +57,12 @@ def varvalues(varname, vartype):
     # gemm, gemv, axpy, etc.
     dimM = 1000
     dimN = 1000
-    dimK = 400  # needs to be less than half-width due to ?TB?V functions
+    dimK = 1000  # needs to be set manually to half-width due to ?TB?V functions
     dimX = 1000
     dimY = 1000
+    # dimensions are currently constrained because matrix dimensions are not
+    # consistently name, e.g. dimA = M-by-K in some routines and M-by-N in others
+    assert (dimM == dimN == dimK == dimX == dimY)
     incX = 1
     incY = 1
     alphaReal = realScalar
@@ -92,7 +98,7 @@ def varvalues(varname, vartype):
         Uplo = 'CblasUpper'
         Side = 'CblasLeft'
         Diag = 'CblasNonUnit'
-        Layout = 'CblasRowMajor' # only exist for Cblas API
+        Layout = 'CblasColMajor' # only exists for Cblas API, make it behave like the Fortran API
     result = 1
 
     # Coverage for batch and batch_strided interfaces are needed here

--- a/template/gemm.cpp.jinja2
+++ b/template/gemm.cpp.jinja2
@@ -225,9 +225,9 @@ int main( int argc, char* argv[] )
 	     cerr << "Expected: " << {{name}}_cpu[i].imag << " Got: " << {{name}}_gpu[i].imag << endl;
 	     cerr << "Expected: " << {{name}}_cpu[i].real << " Got: " << {{name}}_gpu[i].real << endl;
 	     {%- else %}
-      	     std::cerr << "Expected: " << {{name}}_cpu[i] << " Got: " << {{name}}_gpu[i] << std::endl;
+             cerr << "Expected: " << {{name}}_cpu[i] << " Got: " << {{name}}_gpu[i] << endl;
 	     {%- endif %}
-	     std::exit(112);
+	     exit(112);
              }       
            }
         {%- else %}

--- a/template/gemm.cpp.jinja2
+++ b/template/gemm.cpp.jinja2
@@ -5,12 +5,16 @@
 using namespace std;
 
 {%- for t in l_unique_type %}
-bool almost_equal({{t}} x, {{t}} gold, {{t}} tol) {
+bool almost_equal({{t}} x, {{t}} gold, {{t}} rel_tol, {{t}} abs_tol) {
+  // Based on this Python implementation
+  https://docs.python.org/3/library/math.html#math.isclose
+
   bool close_enough = false;
   {%- if t == "MKL_Complex8" or t == "MKL_Complex16" %}
-  close_enough = (std::abs((gold.real-x.real)/gold.real) <= tol.real) && (std::abs((gold.imag-x.imag)/gold.imag) <= tol.real);
+  close_enough = ((abs(gold.real-x.real) <= max(rel_tol.real * max(abs(gold.real), abs(x.real)), abs_tol.real)) &&
+                  (abs(gold.imag-x.imag) <= max(rel_tol.imag * max(abs(gold.imag), abs(x.imag)), abs_tol.imag)));
   {%- else %}
-  close_enough = (std::abs((gold - x)/gold) <= tol);
+  close_enough = (abs(gold-x) <= max(rel_tol * max(abs(gold), abs(x)), abs_tol));
   {%- endif %}
 
   return close_enough;

--- a/template/gemm.cpp.jinja2
+++ b/template/gemm.cpp.jinja2
@@ -2,6 +2,7 @@
 #include <cmath>
 #include "mkl.h"
 #include "mkl_omp_offload.h"
+using namespace std;
 
 {%- for t in l_unique_type %}
 bool almost_equal({{t}} x, {{t}} gold, {{t}} tol) {
@@ -190,9 +191,9 @@ int main( int argc, char* argv[] )
 
 {%- if l_return %}
 
-  if (!almost_equal({{l_return[0][2]}}_gpu, {{l_return[0][2]}}_cpu, 0.1)) {
-    std::cerr << "Expected: " << {{l_return[0][2]}}_cpu << " Got: " << {{l_return[0][2]}}_gpu << std::endl;
-    std::exit(112);
+  if (!almost_equal({{l_return[0][2]}}_gpu, {{l_return[0][2]}}_cpu, 0.01, 0.01)) {
+    cerr << "Expected: " << {{l_return[0][2]}}_cpu << " Got: " << {{l_return[0][2]}}_gpu << endl;
+    exit(112);
   }
 
 {%- endif %}
@@ -214,11 +215,11 @@ int main( int argc, char* argv[] )
 
          {%- if pointer %}
 	   for(int i=0;i<{{size}};i++) {
-             if (not(almost_equal({{name}}_gpu[i], {{name}}_cpu[i], {{name}}_tol))) {
-	     std::cerr << "i: " << i << std::endl;
+             if (not(almost_equal({{name}}_gpu[i], {{name}}_cpu[i], {{name}}_tol, {{name}}_tol))) {
+	     cerr << "i: " << i << endl;
 	     {%- if t == "MKL_Complex8" or t == "MKL_Complex16" %}
-	     std::cerr << "Expected: " << {{name}}_cpu[i].imag << " Got: " << {{name}}_gpu[i].imag << std::endl;
-	     std::cerr << "Expected: " << {{name}}_cpu[i].real << " Got: " << {{name}}_gpu[i].real << std::endl;
+	     cerr << "Expected: " << {{name}}_cpu[i].imag << " Got: " << {{name}}_gpu[i].imag << endl;
+	     cerr << "Expected: " << {{name}}_cpu[i].real << " Got: " << {{name}}_gpu[i].real << endl;
 	     {%- else %}
       	     std::cerr << "Expected: " << {{name}}_cpu[i] << " Got: " << {{name}}_gpu[i] << std::endl;
 	     {%- endif %}
@@ -226,14 +227,14 @@ int main( int argc, char* argv[] )
              }       
            }
         {%- else %}
-             if (not(almost_equal({{name}}_gpu, {{name}}_cpu, {{name}}_tol))) {
+             if (not(almost_equal({{name}}_gpu, {{name}}_cpu, {{name}}_tol, {{name}}_tol))) {
              {%- if t == "MKL_Complex8" or t == "MKL_Complex16" %}
-             std::cerr << "Expected: " << {{name}}_cpu.imag << " Got: " << {{name}}_gpu.imag << std::endl;
-             std::cerr << "Expected: " << {{name}}_cpu.real << " Got: " << {{name}}_gpu.real << std::endl;
+             cerr << "Expected: " << {{name}}_cpu.imag << " Got: " << {{name}}_gpu.imag << endl;
+             cerr << "Expected: " << {{name}}_cpu.real << " Got: " << {{name}}_gpu.real << endl;
              {%- else %}
-             std::cerr << "Expected: " << {{name}}_cpu << " Got: " << {{name}}_gpu << std::endl;
+             cerr << "Expected: " << {{name}}_cpu << " Got: " << {{name}}_gpu << endl;
 	     {%- endif %}
-             std::exit(112);
+             exit(112);
              }       
         {%- endif %}
 

--- a/template/gemm.cpp.jinja2
+++ b/template/gemm.cpp.jinja2
@@ -195,7 +195,7 @@ int main( int argc, char* argv[] )
 
 {%- if l_return %}
 
-  if (!almost_equal({{l_return[0][2]}}_gpu, {{l_return[0][2]}}_cpu, 0.01, 0.01)) {
+  if (!almost_equal({{l_return[0][2]}}_gpu, {{l_return[0][2]}}_cpu, 0.05, 0.20)) {
     cerr << "Expected: " << {{l_return[0][2]}}_cpu << " Got: " << {{l_return[0][2]}}_gpu << endl;
     exit(112);
   }
@@ -208,18 +208,22 @@ int main( int argc, char* argv[] )
        {%- if intent == "out" or intent == "inout" %}
 
        // tolerance
-       {{t}} {{name}}_tol;
+       {{t}} {{name}}_rel_tol;
+       {{t}} {{name}}_abs_tol;
 
        {%- if t == "MKL_Complex8" or t == "MKL_Complex16" %}
-       {{name}}_tol.real = 0.01;
-       {{name}}_tol.imag = 0.01;
+       {{name}}_rel_tol.real = 0.05;
+       {{name}}_rel_tol.imag = 0.05;
+       {{name}}_abs_tol.real = 0.20;
+       {{name}}_abs_tol.imag = 0.20;
        {%- else %}
-       {{name}}_tol = 0.01;
+       {{name}}_rel_tol = 0.05;
+       {{name}}_abs_tol = 0.20;
        {%- endif %}
 
          {%- if pointer %}
 	   for(int i=0;i<{{size}};i++) {
-             if (not(almost_equal({{name}}_gpu[i], {{name}}_cpu[i], {{name}}_tol, {{name}}_tol))) {
+             if (not(almost_equal({{name}}_gpu[i], {{name}}_cpu[i], {{name}}_rel_tol, {{name}}_abs_tol))) {
 	     cerr << "i: " << i << endl;
 	     {%- if t == "MKL_Complex8" or t == "MKL_Complex16" %}
 	     cerr << "Expected: " << {{name}}_cpu[i].imag << " Got: " << {{name}}_gpu[i].imag << endl;
@@ -231,7 +235,7 @@ int main( int argc, char* argv[] )
              }       
            }
         {%- else %}
-             if (not(almost_equal({{name}}_gpu, {{name}}_cpu, {{name}}_tol, {{name}}_tol))) {
+             if (not(almost_equal({{name}}_gpu, {{name}}_cpu, {{name}}_rel_tol, {{name}}_abs_tol))) {
              {%- if t == "MKL_Complex8" or t == "MKL_Complex16" %}
              cerr << "Expected: " << {{name}}_cpu.imag << " Got: " << {{name}}_gpu.imag << endl;
              cerr << "Expected: " << {{name}}_cpu.real << " Got: " << {{name}}_gpu.real << endl;


### PR DESCRIPTION
`parse_header.py` sets `M=N=K`. For `cblas_??b?v` functions, `K` has a special meaning and so we filter these functions out and specialize their value in `gtest.py`. It is currently set to be equal to `M` and reduce this value of `K` by at least a factor of 2.